### PR TITLE
fix: improve DNS robustness and refine timeout logic

### DIFF
--- a/dara/core.go
+++ b/dara/core.go
@@ -323,7 +323,7 @@ func DoRequest(request *Request, runtimeObject *RuntimeObject) (response *Respon
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -442,7 +442,7 @@ func DoRequestWithCtx(ctx context.Context, request *Request, runtimeObject *Runt
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -504,6 +504,7 @@ func DoRequestWithCtx(ctx context.Context, request *Request, runtimeObject *Runt
 
 func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, error) {
 	trans := new(http.Transport)
+	trans.ResponseHeaderTimeout = time.Duration(IntValue(runtime.ReadTimeout)) * time.Millisecond
 	httpProxy, err := getHttpProxy(StringValue(req.Protocol), StringValue(req.Domain), runtime)
 	if err != nil {
 		return nil, err
@@ -696,7 +697,7 @@ func getSocks5Proxy(runtime *RuntimeObject) (proxy *url.URL, err error) {
 func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 	if localAddr != "" {
 		addr = &net.TCPAddr{
-			IP: []byte(localAddr),
+			IP: net.ParseIP(localAddr),
 		}
 	}
 	return addr
@@ -704,20 +705,17 @@ func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 
 func setDialContext(runtime *RuntimeObject) func(cxt context.Context, net, addr string) (c net.Conn, err error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		if runtime.LocalAddr != nil && StringValue(runtime.LocalAddr) != "" {
-			netAddr := &net.TCPAddr{
-				IP: []byte(StringValue(runtime.LocalAddr)),
-			}
-			return (&net.Dialer{
-				Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Second,
-				DualStack: true,
-				LocalAddr: netAddr,
-			}).DialContext(ctx, network, address)
+		timeout := time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond
+		dialer := &net.Dialer{
+			Timeout: timeout,
+			Resolver: &net.Resolver{
+				PreferGo: false,
+			},
 		}
-		return (&net.Dialer{
-			Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Second,
-			DualStack: true,
-		}).DialContext(ctx, network, address)
+		if runtime.LocalAddr != nil && StringValue(runtime.LocalAddr) != "" {
+			dialer.LocalAddr = getLocalAddr(StringValue(runtime.LocalAddr))
+		}
+		return dialer.DialContext(ctx, network, address)
 	}
 }
 

--- a/dara/core_test.go
+++ b/dara/core_test.go
@@ -1531,3 +1531,49 @@ func TestForceUint64(t *testing.T) {
 		}
 	}
 }
+
+func Test_getLocalAddr(t *testing.T) {
+	// Test empty address
+	addr := getLocalAddr("")
+	utils.AssertNil(t, addr)
+
+	// Test valid IPv4 address
+	addr = getLocalAddr("127.0.0.1")
+	utils.AssertNotNil(t, addr)
+	utils.AssertEqual(t, "127.0.0.1", addr.IP.String())
+
+	// Test valid IPv6 address
+	addr = getLocalAddr("::1")
+	utils.AssertNotNil(t, addr)
+	utils.AssertEqual(t, "::1", addr.IP.String())
+
+	// Test invalid IP
+	addr = getLocalAddr("invalid")
+	utils.AssertNotNil(t, addr)
+	utils.AssertNil(t, addr.IP)
+}
+
+func Test_setDialContext(t *testing.T) {
+	runtime := &RuntimeObject{
+		ConnectTimeout: Int(1000),
+		LocalAddr:      String("127.0.0.1"),
+	}
+	dialerFunc := setDialContext(runtime)
+	utils.AssertNotNil(t, dialerFunc)
+}
+
+func Test_TimeoutLogic(t *testing.T) {
+	runtime := &RuntimeObject{
+		ConnectTimeout: Int(1000),
+		ReadTimeout:    Int(2000),
+	}
+	
+	req := &Request{
+		Protocol: String("http"),
+		Domain:   String("localhost"),
+	}
+	trans, err := getHttpTransport(req, runtime)
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, trans)
+	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
+}

--- a/tea/tea.go
+++ b/tea/tea.go
@@ -386,7 +386,7 @@ func DoRequest(request *Request, requestRuntime map[string]interface{}) (respons
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -442,6 +442,7 @@ func DoRequest(request *Request, requestRuntime map[string]interface{}) (respons
 
 func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, error) {
 	trans := new(http.Transport)
+	trans.ResponseHeaderTimeout = time.Duration(IntValue(runtime.ReadTimeout)) * time.Millisecond
 	httpProxy, err := getHttpProxy(StringValue(req.Protocol), StringValue(req.Domain), runtime)
 	if err != nil {
 		return nil, err
@@ -602,7 +603,7 @@ func getSocks5Proxy(runtime *RuntimeObject) (proxy *url.URL, err error) {
 func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 	if localAddr != "" {
 		addr = &net.TCPAddr{
-			IP: []byte(localAddr),
+			IP: net.ParseIP(localAddr),
 		}
 	}
 	return addr
@@ -610,20 +611,18 @@ func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 
 func setDialContext(runtime *RuntimeObject) func(cxt context.Context, net, addr string) (c net.Conn, err error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		if runtime.LocalAddr != nil && StringValue(runtime.LocalAddr) != "" {
-			netAddr := &net.TCPAddr{
-				IP: []byte(StringValue(runtime.LocalAddr)),
-			}
-			return (&net.Dialer{
-				Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Second,
-				DualStack: true,
-				LocalAddr: netAddr,
-			}).DialContext(ctx, network, address)
-		}
-		return (&net.Dialer{
-			Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Second,
+		timeout := time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond
+		dialer := &net.Dialer{
+			Timeout: timeout,
+			Resolver: &net.Resolver{
+				PreferGo: false,
+			},
 			DualStack: true,
-		}).DialContext(ctx, network, address)
+		}
+		if runtime.LocalAddr != nil && StringValue(runtime.LocalAddr) != "" {
+			dialer.LocalAddr = getLocalAddr(StringValue(runtime.LocalAddr))
+		}
+		return dialer.DialContext(ctx, network, address)
 	}
 }
 

--- a/tea/tea_test.go
+++ b/tea/tea_test.go
@@ -967,3 +967,49 @@ func Test_TransInt32AndInt(t *testing.T) {
 	b := ToInt32(a)
 	utils.AssertEqual(t, Int32Value(b), int32(10))
 }
+
+func Test_getLocalAddr(t *testing.T) {
+	// Test empty address
+	addr := getLocalAddr("")
+	utils.AssertNil(t, addr)
+
+	// Test valid IPv4 address
+	addr = getLocalAddr("127.0.0.1")
+	utils.AssertNotNil(t, addr)
+	utils.AssertEqual(t, "127.0.0.1", addr.IP.String())
+
+	// Test valid IPv6 address
+	addr = getLocalAddr("::1")
+	utils.AssertNotNil(t, addr)
+	utils.AssertEqual(t, "::1", addr.IP.String())
+
+	// Test invalid IP
+	addr = getLocalAddr("invalid")
+	utils.AssertNotNil(t, addr)
+	utils.AssertNil(t, addr.IP)
+}
+
+func Test_setDialContext(t *testing.T) {
+	runtime := &RuntimeObject{
+		ConnectTimeout: Int(1000),
+		LocalAddr:      String("127.0.0.1"),
+	}
+	dialerFunc := setDialContext(runtime)
+	utils.AssertNotNil(t, dialerFunc)
+}
+
+func Test_TimeoutLogic(t *testing.T) {
+	runtime := &RuntimeObject{
+		ConnectTimeout: Int(1000),
+		ReadTimeout:    Int(2000),
+	}
+	
+	req := &Request{
+		Protocol: String("http"),
+		Domain:   String("localhost"),
+	}
+	trans, err := getHttpTransport(req, runtime)
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, trans)
+	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
+}


### PR DESCRIPTION
- Fix DNS resolution failure by prioritizing CGO resolver (PreferGo: false) to stay consistent with system tools like curl when /etc/resolv.conf contains invalid nameservers.
- Fix logic bug in getLocalAddr where LocalAddr string was incorrectly cast to []byte instead of being parsed via net.ParseIP.
- Refactor HTTP timeout logic:
    * Set httpClient.Timeout to ConnectTimeout + ReadTimeout.
    * Set http.Transport.ResponseHeaderTimeout to ReadTimeout for granular control.
- Add unit tests for LocalAddr parsing, dial context, and timeout configuration in both tea and dara packages.