### PR TITLE
fix: apply default connect/read timeouts when unset

### DIFF
--- a/dara/core.go
+++ b/dara/core.go
@@ -70,6 +70,28 @@ var validateParams = []string{"require", "pattern", "maxLength", "minLength", "m
 
 var clientPool = &sync.Map{}
 
+// Default timeouts when RuntimeObject leaves connect/read timeout unset.
+// Align with tea-python (DEFAULT_CONNECT_TIMEOUT=5000, DEFAULT_READ_TIMEOUT=10000)
+// and Go http.DefaultTransport dial/TLS defaults so requests cannot hang forever.
+const (
+	defaultConnectTimeoutMs = 5000
+	defaultReadTimeoutMs    = 10000
+)
+
+func resolveConnectTimeoutMs(runtime *RuntimeObject) int {
+	if runtime != nil && runtime.ConnectTimeout != nil && IntValue(runtime.ConnectTimeout) > 0 {
+		return IntValue(runtime.ConnectTimeout)
+	}
+	return defaultConnectTimeoutMs
+}
+
+func resolveReadTimeoutMs(runtime *RuntimeObject) int {
+	if runtime != nil && runtime.ReadTimeout != nil && IntValue(runtime.ReadTimeout) > 0 {
+		return IntValue(runtime.ReadTimeout)
+	}
+	return defaultReadTimeoutMs
+}
+
 // Request is used wrap http request
 type Request struct {
 	Protocol *string
@@ -351,7 +373,7 @@ func DoRequest(request *Request, runtimeObject *RuntimeObject) (response *Respon
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(resolveConnectTimeoutMs(runtimeObject)+resolveReadTimeoutMs(runtimeObject)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -470,7 +492,7 @@ func DoRequestWithCtx(ctx context.Context, request *Request, runtimeObject *Runt
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(resolveConnectTimeoutMs(runtimeObject)+resolveReadTimeoutMs(runtimeObject)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -531,8 +553,14 @@ func DoRequestWithCtx(ctx context.Context, request *Request, runtimeObject *Runt
 }
 
 func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, error) {
+	connectTimeoutMs := resolveConnectTimeoutMs(runtime)
+	readTimeoutMs := resolveReadTimeoutMs(runtime)
 	trans := new(http.Transport)
-	trans.ResponseHeaderTimeout = time.Duration(IntValue(runtime.ReadTimeout)) * time.Millisecond
+	trans.ResponseHeaderTimeout = time.Duration(readTimeoutMs) * time.Millisecond
+	// Align with http.DefaultTransport so a zero-value Transport cannot hang forever.
+	trans.TLSHandshakeTimeout = 10 * time.Second
+	trans.ExpectContinueTimeout = 1 * time.Second
+	trans.IdleConnTimeout = 90 * time.Second
 	httpProxy, err := getHttpProxy(StringValue(req.Protocol), StringValue(req.Domain), runtime)
 	if err != nil {
 		return nil, err
@@ -588,7 +616,7 @@ func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, er
 			}
 			dialer, err := proxy.SOCKS5(strings.ToLower(StringValue(runtime.Socks5NetWork)), socks5Proxy.Host, auth,
 				&net.Dialer{
-					Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond,
+					Timeout:   time.Duration(connectTimeoutMs) * time.Millisecond,
 					DualStack: true,
 					LocalAddr: getLocalAddr(StringValue(runtime.LocalAddr)),
 				})
@@ -733,7 +761,7 @@ func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 
 func setDialContext(runtime *RuntimeObject) func(cxt context.Context, net, addr string) (c net.Conn, err error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		timeout := time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond
+		timeout := time.Duration(resolveConnectTimeoutMs(runtime)) * time.Millisecond
 		dialer := &net.Dialer{
 			Timeout: timeout,
 			Resolver: &net.Resolver{

--- a/dara/core_test.go
+++ b/dara/core_test.go
@@ -1589,3 +1589,84 @@ func Test_TimeoutLogic(t *testing.T) {
 	utils.AssertNotNil(t, trans)
 	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
 }
+
+func Test_DefaultTimeouts(t *testing.T) {
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(nil))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(nil))
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(&RuntimeObject{}))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(&RuntimeObject{}))
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(&RuntimeObject{ConnectTimeout: Int(0)}))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(&RuntimeObject{ReadTimeout: Int(0)}))
+	utils.AssertEqual(t, 3000, resolveConnectTimeoutMs(&RuntimeObject{ConnectTimeout: Int(3000)}))
+	utils.AssertEqual(t, 7000, resolveReadTimeoutMs(&RuntimeObject{ReadTimeout: Int(7000)}))
+
+	req := &Request{
+		Protocol: String("http"),
+		Domain:   String("localhost"),
+		Headers:  map[string]*string{},
+	}
+	trans, err := getHttpTransport(req, &RuntimeObject{})
+	utils.AssertNil(t, err)
+	utils.AssertEqual(t, time.Duration(defaultReadTimeoutMs)*time.Millisecond, trans.ResponseHeaderTimeout)
+	utils.AssertEqual(t, 10*time.Second, trans.TLSHandshakeTimeout)
+	utils.AssertEqual(t, 1*time.Second, trans.ExpectContinueTimeout)
+	utils.AssertEqual(t, 90*time.Second, trans.IdleConnTimeout)
+
+	trans, err = getHttpTransport(req, &RuntimeObject{
+		ConnectTimeout: Int(1000),
+		ReadTimeout:    Int(2000),
+		IdleTimeout:    Int(3000),
+	})
+	utils.AssertNil(t, err)
+	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
+	utils.AssertEqual(t, time.Duration(3000)*time.Millisecond, trans.IdleConnTimeout)
+
+	origTestHookDo := hookDo
+	defer func() { hookDo = origTestHookDo }()
+	var capturedClientTimeout time.Duration
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			tag := (&RuntimeObject{}).getClientTag(req.Host)
+			client := getDaraClient(tag)
+			capturedClientTimeout = client.httpClient.Timeout
+			return mockResponse(200, ``, nil)
+		}
+	}
+	request := NewRequest()
+	request.Headers["host"] = String("timeout-default.example.com")
+	resp, err := DoRequest(request, &RuntimeObject{})
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, time.Duration(defaultConnectTimeoutMs+defaultReadTimeoutMs)*time.Millisecond, capturedClientTimeout)
+
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			tag := (&RuntimeObject{ConnectTimeout: Int(1000), ReadTimeout: Int(2000)}).getClientTag(req.Host)
+			client := getDaraClient(tag)
+			capturedClientTimeout = client.httpClient.Timeout
+			return mockResponse(200, ``, nil)
+		}
+	}
+	request = NewRequest()
+	request.Headers["host"] = String("timeout-explicit.example.com")
+	resp, err = DoRequest(request, &RuntimeObject{ConnectTimeout: Int(1000), ReadTimeout: Int(2000)})
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, time.Duration(3000)*time.Millisecond, capturedClientTimeout)
+
+	ctx := context.Background()
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			tag := (&RuntimeObject{}).getClientTag(req.Host)
+			client := getDaraClient(tag)
+			capturedClientTimeout = client.httpClient.Timeout
+			return mockResponse(200, ``, nil)
+		}
+	}
+	request = NewRequest()
+	request.Headers["host"] = String("timeout-default-ctx.example.com")
+	resp, err = DoRequestWithCtx(ctx, request, &RuntimeObject{})
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, time.Duration(defaultConnectTimeoutMs+defaultReadTimeoutMs)*time.Millisecond, capturedClientTimeout)
+}

--- a/tea/tea.go
+++ b/tea/tea.go
@@ -123,6 +123,28 @@ type RuntimeObject struct {
 
 var clientPool = &sync.Map{}
 
+// Default timeouts when RuntimeObject leaves connect/read timeout unset.
+// Align with tea-python (DEFAULT_CONNECT_TIMEOUT=5000, DEFAULT_READ_TIMEOUT=10000)
+// and Go http.DefaultTransport dial/TLS defaults so requests cannot hang forever.
+const (
+	defaultConnectTimeoutMs = 5000
+	defaultReadTimeoutMs    = 10000
+)
+
+func resolveConnectTimeoutMs(runtime *RuntimeObject) int {
+	if runtime != nil && runtime.ConnectTimeout != nil && IntValue(runtime.ConnectTimeout) > 0 {
+		return IntValue(runtime.ConnectTimeout)
+	}
+	return defaultConnectTimeoutMs
+}
+
+func resolveReadTimeoutMs(runtime *RuntimeObject) int {
+	if runtime != nil && runtime.ReadTimeout != nil && IntValue(runtime.ReadTimeout) > 0 {
+		return IntValue(runtime.ReadTimeout)
+	}
+	return defaultReadTimeoutMs
+}
+
 func (r *RuntimeObject) getClientTag(domain string) string {
 	return strconv.FormatBool(BoolValue(r.IgnoreSSL)) + strconv.Itoa(IntValue(r.ReadTimeout)) +
 		strconv.Itoa(IntValue(r.ConnectTimeout)) + StringValue(r.LocalAddr) + StringValue(r.HttpProxy) +
@@ -386,7 +408,7 @@ func DoRequest(request *Request, requestRuntime map[string]interface{}) (respons
 		if !defaultClient.ifInit || defaultClient.httpClient.Transport == nil {
 			defaultClient.httpClient.Transport = trans
 		}
-		defaultClient.httpClient.Timeout = time.Duration(IntValue(runtimeObject.ConnectTimeout)+IntValue(runtimeObject.ReadTimeout)) * time.Millisecond
+		defaultClient.httpClient.Timeout = time.Duration(resolveConnectTimeoutMs(runtimeObject)+resolveReadTimeoutMs(runtimeObject)) * time.Millisecond
 		defaultClient.ifInit = true
 		defaultClient.Unlock()
 	}
@@ -441,8 +463,14 @@ func DoRequest(request *Request, requestRuntime map[string]interface{}) (respons
 }
 
 func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, error) {
+	connectTimeoutMs := resolveConnectTimeoutMs(runtime)
+	readTimeoutMs := resolveReadTimeoutMs(runtime)
 	trans := new(http.Transport)
-	trans.ResponseHeaderTimeout = time.Duration(IntValue(runtime.ReadTimeout)) * time.Millisecond
+	trans.ResponseHeaderTimeout = time.Duration(readTimeoutMs) * time.Millisecond
+	// Align with http.DefaultTransport so a zero-value Transport cannot hang forever.
+	trans.TLSHandshakeTimeout = 10 * time.Second
+	trans.ExpectContinueTimeout = 1 * time.Second
+	trans.IdleConnTimeout = 90 * time.Second
 	httpProxy, err := getHttpProxy(StringValue(req.Protocol), StringValue(req.Domain), runtime)
 	if err != nil {
 		return nil, err
@@ -498,7 +526,7 @@ func getHttpTransport(req *Request, runtime *RuntimeObject) (*http.Transport, er
 			}
 			dialer, err := proxy.SOCKS5(strings.ToLower(StringValue(runtime.Socks5NetWork)), socks5Proxy.Host, auth,
 				&net.Dialer{
-					Timeout:   time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond,
+					Timeout:   time.Duration(connectTimeoutMs) * time.Millisecond,
 					DualStack: true,
 					LocalAddr: getLocalAddr(StringValue(runtime.LocalAddr)),
 				})
@@ -611,7 +639,7 @@ func getLocalAddr(localAddr string) (addr *net.TCPAddr) {
 
 func setDialContext(runtime *RuntimeObject) func(cxt context.Context, net, addr string) (c net.Conn, err error) {
 	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		timeout := time.Duration(IntValue(runtime.ConnectTimeout)) * time.Millisecond
+		timeout := time.Duration(resolveConnectTimeoutMs(runtime)) * time.Millisecond
 		dialer := &net.Dialer{
 			Timeout: timeout,
 			Resolver: &net.Resolver{

--- a/tea/tea_test.go
+++ b/tea/tea_test.go
@@ -1003,7 +1003,7 @@ func Test_TimeoutLogic(t *testing.T) {
 		ConnectTimeout: Int(1000),
 		ReadTimeout:    Int(2000),
 	}
-	
+
 	req := &Request{
 		Protocol: String("http"),
 		Domain:   String("localhost"),
@@ -1012,4 +1012,63 @@ func Test_TimeoutLogic(t *testing.T) {
 	utils.AssertNil(t, err)
 	utils.AssertNotNil(t, trans)
 	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
+}
+
+func Test_DefaultTimeouts(t *testing.T) {
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(nil))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(nil))
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(&RuntimeObject{}))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(&RuntimeObject{}))
+	utils.AssertEqual(t, defaultConnectTimeoutMs, resolveConnectTimeoutMs(&RuntimeObject{ConnectTimeout: Int(0)}))
+	utils.AssertEqual(t, defaultReadTimeoutMs, resolveReadTimeoutMs(&RuntimeObject{ReadTimeout: Int(0)}))
+	utils.AssertEqual(t, 3000, resolveConnectTimeoutMs(&RuntimeObject{ConnectTimeout: Int(3000)}))
+	utils.AssertEqual(t, 7000, resolveReadTimeoutMs(&RuntimeObject{ReadTimeout: Int(7000)}))
+
+	req := &Request{
+		Protocol: String("http"),
+		Domain:   String("localhost"),
+		Headers:  map[string]*string{},
+	}
+	trans, err := getHttpTransport(req, &RuntimeObject{})
+	utils.AssertNil(t, err)
+	utils.AssertEqual(t, time.Duration(defaultReadTimeoutMs)*time.Millisecond, trans.ResponseHeaderTimeout)
+	utils.AssertEqual(t, 10*time.Second, trans.TLSHandshakeTimeout)
+	utils.AssertEqual(t, 1*time.Second, trans.ExpectContinueTimeout)
+	utils.AssertEqual(t, 90*time.Second, trans.IdleConnTimeout)
+
+	origTestHookDo := hookDo
+	defer func() { hookDo = origTestHookDo }()
+	var capturedClientTimeout time.Duration
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			tag := (&RuntimeObject{}).getClientTag(req.Host)
+			client := getTeaClient(tag)
+			capturedClientTimeout = client.httpClient.Timeout
+			return mockResponse(200, ``, nil)
+		}
+	}
+	request := NewRequest()
+	request.Headers["host"] = String("timeout-default.example.com")
+	resp, err := DoRequest(request, map[string]interface{}{})
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, time.Duration(defaultConnectTimeoutMs+defaultReadTimeoutMs)*time.Millisecond, capturedClientTimeout)
+
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			tag := (&RuntimeObject{ConnectTimeout: Int(1000), ReadTimeout: Int(2000)}).getClientTag(req.Host)
+			client := getTeaClient(tag)
+			capturedClientTimeout = client.httpClient.Timeout
+			return mockResponse(200, ``, nil)
+		}
+	}
+	request = NewRequest()
+	request.Headers["host"] = String("timeout-explicit.example.com")
+	resp, err = DoRequest(request, map[string]interface{}{
+		"connectTimeout": 1000,
+		"readTimeout":    2000,
+	})
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, time.Duration(3000)*time.Millisecond, capturedClientTimeout)
 }


### PR DESCRIPTION
## Summary
- Empty RuntimeOptions no longer leave http.Client.Timeout / Transport timeouts at zero
- Fall back to connect=5s and read=10s (aligned with tea-python) plus DefaultTransport TLS/idle defaults
- Explicit ConnectTimeout / ReadTimeout / IdleTimeout overrides are preserved