### PR TITLE
test: raise overall statement coverage to ≥90%

### DIFF
--- a/dara/array_test.go
+++ b/dara/array_test.go
@@ -403,6 +403,22 @@ func TestConcatArr(t *testing.T) {
 	if !reflect.DeepEqual(result, expectedMixed) {
 		t.Errorf("Expected '%v', but got '%v'", expectedMixed, result)
 	}
+
+	// Same-type non-pointer slices use reflect.MakeSlice path
+	plainIntArr1 := []int{1, 2}
+	plainIntArr2 := []int{3, 4}
+	result = ConcatArr(plainIntArr1, plainIntArr2)
+	expectedPlainInts := []int{1, 2, 3, 4}
+	if !reflect.DeepEqual(result, expectedPlainInts) {
+		t.Errorf("Expected '%v', but got '%v'", expectedPlainInts, result)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for non-slice inputs")
+		}
+	}()
+	ConcatArr("not", "slice")
 }
 
 func TestArrAppend(t *testing.T) {

--- a/dara/core_test.go
+++ b/dara/core_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"strconv"
@@ -1588,4 +1589,82 @@ func Test_TimeoutLogic(t *testing.T) {
 	utils.AssertNil(t, err)
 	utils.AssertNotNil(t, trans)
 	utils.AssertEqual(t, time.Duration(2000)*time.Millisecond, trans.ResponseHeaderTimeout)
+}
+
+func Test_daraClient_Call(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	client := &daraClient{
+		httpClient: &http.Client{},
+	}
+	req, err := http.NewRequest("GET", server.URL, nil)
+	utils.AssertNil(t, err)
+
+	resp, err := client.Call(req, nil)
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+}
+
+func Test_IsNil(t *testing.T) {
+	utils.AssertEqual(t, true, IsNil(nil))
+
+	var nilStr *string
+	utils.AssertEqual(t, true, IsNil(nilStr))
+
+	var nilSlice []string
+	utils.AssertEqual(t, true, IsNil(nilSlice))
+
+	var nilMap map[string]string
+	utils.AssertEqual(t, true, IsNil(nilMap))
+
+	str := "hello"
+	utils.AssertEqual(t, false, IsNil(&str))
+	utils.AssertEqual(t, false, IsNil(str))
+	// Non-nillable scalars: reflect.Value == Zero is not value-equality, so IsNil(0)/IsNil("") are false.
+	utils.AssertEqual(t, false, IsNil(0))
+	utils.AssertEqual(t, false, IsNil(""))
+	utils.AssertEqual(t, false, IsNil([]string{"a"}))
+	utils.AssertEqual(t, false, IsNil(map[string]string{"a": "b"}))
+}
+
+func Test_BytesFromString(t *testing.T) {
+	utils.AssertEqual(t, []byte("hello"), BytesFromString("hello", "utf8"))
+	utils.AssertEqual(t, []byte("Hello, World!"), BytesFromString("48656c6c6f2c20576f726c6421", "hex"))
+	utils.AssertEqual(t, []byte("Hello, World!"), BytesFromString("SGVsbG8sIFdvcmxkIQ==", "base64"))
+	utils.AssertNil(t, BytesFromString("invalid hex", "hex"))
+	utils.AssertNil(t, BytesFromString("invalid base64", "base64"))
+	utils.AssertNil(t, BytesFromString("hello", "unsupported"))
+}
+
+func Test_DoRequestWithCtxSuccess(t *testing.T) {
+	origTestHookDo := hookDo
+	defer func() { hookDo = origTestHookDo }()
+	hookDo = func(fn func(req *http.Request, transport *http.Transport) (*http.Response, error)) func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+		return func(req *http.Request, transport *http.Transport) (*http.Response, error) {
+			return mockResponse(200, `{"ok":true}`, nil)
+		}
+	}
+
+	request := NewRequest()
+	request.Method = String("GET")
+	request.Protocol = String("http")
+	request.Pathname = String("/api")
+	request.Headers["host"] = String("example.com")
+	request.Query = map[string]*string{"key": String("value")}
+
+	ctx := context.Background()
+	resp, err := DoRequestWithCtx(ctx, request, NewRuntimeObject(runtimeObj))
+	utils.AssertNil(t, err)
+	utils.AssertNotNil(t, resp)
+	utils.AssertEqual(t, 200, IntValue(resp.StatusCode))
+}
+
+func Test_ToStringBytes(t *testing.T) {
+	utils.AssertEqual(t, "hello", ToString([]byte("hello")))
 }

--- a/dara/date_test.go
+++ b/dara/date_test.go
@@ -106,6 +106,69 @@ func TestDiff(t *testing.T) {
 	if diffInSeconds != -31*24*60*60 {
 		t.Errorf("Expected %v, got %v", -31*24*60*60, diffInSeconds)
 	}
+
+	if date1.Diff("minutes", date2) != -31*24*60 {
+		t.Errorf("unexpected minutes diff: %v", date1.Diff("minutes", date2))
+	}
+	if date1.Diff("hours", date2) != -31*24 {
+		t.Errorf("unexpected hours diff: %v", date1.Diff("hours", date2))
+	}
+	if date1.Diff("days", date2) != -31 {
+		t.Errorf("unexpected days diff: %v", date1.Diff("days", date2))
+	}
+	if date1.Diff("weeks", date2) != -4 {
+		t.Errorf("unexpected weeks diff: %v", date1.Diff("weeks", date2))
+	}
+	// months uses (diffDate - receiver) calendar months
+	if date1.Diff("months", date2) != 1 {
+		t.Errorf("unexpected months diff: %v", date1.Diff("months", date2))
+	}
+	if date1.Diff("years", date2) != 0 {
+		t.Errorf("unexpected years diff: %v", date1.Diff("years", date2))
+	}
+	if date1.Diff("invalid", date2) != 0 {
+		t.Errorf("expected 0 for invalid unit")
+	}
+}
+
+func TestAddSubUnits(t *testing.T) {
+	datetime := "2023-03-01T12:00:00Z"
+	date, _ := NewDate(datetime)
+
+	units := []struct {
+		unit     string
+		amount   int
+		addExpect time.Time
+		subExpect time.Time
+	}{
+		{"second", 1, time.Date(2023, 3, 1, 12, 0, 1, 0, time.UTC), time.Date(2023, 3, 1, 11, 59, 59, 0, time.UTC)},
+		{"minute", 1, time.Date(2023, 3, 1, 12, 1, 0, 0, time.UTC), time.Date(2023, 3, 1, 11, 59, 0, 0, time.UTC)},
+		{"hour", 1, time.Date(2023, 3, 1, 13, 0, 0, 0, time.UTC), time.Date(2023, 3, 1, 11, 0, 0, 0, time.UTC)},
+		{"week", 1, time.Date(2023, 3, 8, 12, 0, 0, 0, time.UTC), time.Date(2023, 2, 22, 12, 0, 0, 0, time.UTC)},
+		{"month", 1, time.Date(2023, 4, 1, 12, 0, 0, 0, time.UTC), time.Date(2023, 2, 1, 12, 0, 0, 0, time.UTC)},
+		{"year", 1, time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC), time.Date(2022, 3, 1, 12, 0, 0, 0, time.UTC)},
+	}
+
+	for _, tc := range units {
+		base, _ := NewDate(datetime)
+		result := base.Add(tc.amount, tc.unit)
+		if result == nil || !result.date.Equal(tc.addExpect) {
+			t.Errorf("Add(%d, %s): expected %v, got %v", tc.amount, tc.unit, tc.addExpect, result)
+		}
+
+		base, _ = NewDate(datetime)
+		result = base.Sub(tc.amount, tc.unit)
+		if result == nil || !result.date.Equal(tc.subExpect) {
+			t.Errorf("Sub(%d, %s): expected %v, got %v", tc.amount, tc.unit, tc.subExpect, result)
+		}
+	}
+
+	if date.Add(1, "invalid") != nil {
+		t.Error("expected nil for invalid Add unit")
+	}
+	if date.Sub(1, "invalid") != nil {
+		t.Error("expected nil for invalid Sub unit")
+	}
 }
 
 func TestHourMinuteSecond(t *testing.T) {

--- a/dara/error_test.go
+++ b/dara/error_test.go
@@ -1,0 +1,40 @@
+package dara
+
+import (
+	"testing"
+
+	"github.com/alibabacloud-go/tea/utils"
+)
+
+func TestSDKErrorAccessors(t *testing.T) {
+	err := NewSDKError(map[string]interface{}{
+		"code":    "ERR001",
+		"message": "test message",
+	})
+	err.Name = String("CustomError")
+
+	utils.AssertEqual(t, "CustomError", StringValue(err.ErrorName()))
+	utils.AssertEqual(t, "test message", StringValue(err.ErrorMessage()))
+	utils.AssertEqual(t, "ERR001", StringValue(err.GetCode()))
+}
+
+func TestTeaSDKError(t *testing.T) {
+	utils.AssertNil(t, TeaSDKError(nil))
+
+	sdkErr := NewSDKError(map[string]interface{}{
+		"code":       "code",
+		"statusCode": 404,
+		"message":    "message",
+		"description": "description",
+		"detail":      "detail",
+		"accessDeniedDetail": map[string]interface{}{
+			"AuthAction": "ram:ListUsers",
+		},
+	})
+	converted := TeaSDKError(sdkErr)
+	utils.AssertNotNil(t, converted)
+
+	plainErr := NewCastError(String("plain"))
+	converted = TeaSDKError(plainErr)
+	utils.AssertEqual(t, plainErr, converted)
+}

--- a/dara/model_test.go
+++ b/dara/model_test.go
@@ -90,6 +90,26 @@ func TestValidateRequired(t *testing.T) {
 	var nilPtr *string
 	err = ValidateRequired(nilPtr, "testField")
 	utils.AssertEqual(t, "testField should be setted", err.Error())
+
+	nilTypes := []interface{}{
+		(*int)(nil), (*int8)(nil), (*int16)(nil), (*int32)(nil), (*int64)(nil),
+		(*uint)(nil), (*uint8)(nil), (*uint16)(nil), (*uint32)(nil), (*uint64)(nil),
+		(*float32)(nil), (*float64)(nil),
+	}
+	for i, v := range nilTypes {
+		err = ValidateRequired(v, "field")
+		if err == nil {
+			t.Errorf("case %d: expected error for nil typed pointer", i)
+		}
+	}
+
+	i, i8, f32, f64 := 1, int8(1), float32(1.0), float64(1.0)
+	validTypes := []interface{}{&i, &i8, &f32, &f64}
+	for _, v := range validTypes {
+		if err := ValidateRequired(v, "field"); err != nil {
+			t.Errorf("expected nil error for valid pointer, got %v", err)
+		}
+	}
 }
 
 func TestValidateMaxLength(t *testing.T) {

--- a/dara/retry_test.go
+++ b/dara/retry_test.go
@@ -600,6 +600,42 @@ func TestFullJitterBackoffPolicy(t *testing.T) {
 
 }
 
+func TestNewRetryOptions(t *testing.T) {
+	options := NewRetryOptions(map[string]interface{}{
+		"retryable":   true,
+		"maxAttempts": 5,
+		"retryCondition": []interface{}{
+			map[string]interface{}{
+				"maxAttempts": 3,
+				"exception":   []string{"AErr"},
+				"errorCode":   []string{"A1"},
+			},
+		},
+		"noRetryCondition": []interface{}{
+			map[string]interface{}{
+				"maxAttempts": 1,
+				"exception":   []string{"BErr"},
+				"errorCode":   []string{"B1"},
+			},
+		},
+	})
+	if options == nil {
+		t.Fatal("expected non-nil RetryOptions")
+	}
+	if !options.Retryable {
+		t.Error("expected Retryable to be true")
+	}
+	if options.MaxAttempts != 5 {
+		t.Errorf("expected MaxAttempts 5, got %d", options.MaxAttempts)
+	}
+	if len(options.RetryCondition) != 1 {
+		t.Errorf("expected 1 retry condition, got %d", len(options.RetryCondition))
+	}
+	if len(options.NoRetryCondition) != 1 {
+		t.Errorf("expected 1 no-retry condition, got %d", len(options.NoRetryCondition))
+	}
+}
+
 func TestRetryAfter(t *testing.T) {
 	condition1 := NewRetryCondition(map[string]interface{}{
 		"maxAttempts": 3,

--- a/dara/url_test.go
+++ b/dara/url_test.go
@@ -4,6 +4,16 @@ import (
 	"testing"
 )
 
+func TestParseURL(t *testing.T) {
+	u, err := ParseURL("http://example.com/path")
+	if err != nil {
+		t.Fatalf("ParseURL failed: %v", err)
+	}
+	if u.Hostname() != "example.com" {
+		t.Errorf("expected example.com, got %s", u.Hostname())
+	}
+}
+
 func TestNewURL(t *testing.T) {
 	tests := []struct {
 		urlString string

--- a/dara/websocket_test.go
+++ b/dara/websocket_test.go
@@ -665,3 +665,207 @@ func TestConfigureNetDialer(t *testing.T) {
 		t.Error("Expected NetDialContext to be set")
 	}
 }
+
+func TestWebSocketRuntimeGetters(t *testing.T) {
+	ping := Int(1000)
+	pong := Int(2000)
+	enable := Bool(true)
+	reconnect := Int(3000)
+	maxReconnect := Int(5)
+	write := Int(4000)
+	handshake := Int(5000)
+	subProto := String("awap")
+	handler := &MockWebSocketHandler{}
+
+	runtimeOpts := &RuntimeOptions{
+		WebSocketPingInterval:      ping,
+		WebSocketPongTimeout:       pong,
+		WebSocketEnableReconnect:   enable,
+		WebSocketReconnectInterval: reconnect,
+		WebSocketMaxReconnectTimes: maxReconnect,
+		WebSocketWriteTimeout:      write,
+		WebSocketHandshakeTimeout:  handshake,
+		WebSocketHandler:           handler,
+	}
+
+	if GetWebSocketPingInterval(nil) != nil {
+		t.Error("expected nil for nil runtime")
+	}
+	if IntValue(GetWebSocketPingInterval(runtimeOpts)) != 1000 {
+		t.Error("unexpected ping interval")
+	}
+	if IntValue(GetWebSocketPongTimeout(runtimeOpts)) != 2000 {
+		t.Error("unexpected pong timeout")
+	}
+	if !BoolValue(GetWebSocketEnableReconnect(runtimeOpts)) {
+		t.Error("expected reconnect enabled")
+	}
+	if IntValue(GetWebSocketReconnectInterval(runtimeOpts)) != 3000 {
+		t.Error("unexpected reconnect interval")
+	}
+	if IntValue(GetWebSocketMaxReconnectTimes(runtimeOpts)) != 5 {
+		t.Error("unexpected max reconnect times")
+	}
+	if IntValue(GetWebSocketWriteTimeout(runtimeOpts)) != 4000 {
+		t.Error("unexpected write timeout")
+	}
+	if IntValue(GetWebSocketHandshakeTimeout(runtimeOpts)) != 5000 {
+		t.Error("unexpected handshake timeout")
+	}
+	if GetWebSocketHandler(runtimeOpts) == nil {
+		t.Error("expected handler from runtime options")
+	}
+	if GetWebSocketHandler("invalid") != nil {
+		t.Error("expected nil for invalid runtime type")
+	}
+
+	runtimeObj := &RuntimeObject{WebsocketSubProtocol: subProto}
+	if StringValue(GetWebsocketSubProtocol(runtimeObj)) != "awap" {
+		t.Error("unexpected sub protocol")
+	}
+	if GetWebsocketSubProtocol(nil) != nil {
+		t.Error("expected nil sub protocol for nil runtime")
+	}
+}
+
+func TestAbstractWebSocketHandler(t *testing.T) {
+	handler := &AbstractWebSocketHandler{}
+	session := &WebSocketSessionInfo{SessionID: "test"}
+	msg := &WebSocketMessage{Type: WebSocketMessageTypeText, Payload: []byte("hi")}
+
+	if err := handler.AfterConnectionEstablished(session); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := handler.HandleRawMessage(session, msg); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := handler.HandleError(session, errors.New("err")); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := handler.AfterConnectionClosed(session, 1000, "bye"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWebSocketSendAndSession(t *testing.T) {
+	server := createTestWebSocketServer(t)
+	defer server.Close()
+
+	handler := &MockWebSocketHandler{}
+	request := &Request{
+		Protocol: String("ws"),
+		Pathname: String("/"),
+		Headers: map[string]*string{
+			"host": String(server.Listener.Addr().String()),
+		},
+	}
+	runtimeObject := &RuntimeObject{
+		WebSocketPingInterval: Int(0),
+		WebSocketHandler:      handler,
+	}
+
+	client, err := NewDefaultWebSocketClient(handler)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	if err := client.SendText("before connect"); err == nil {
+		t.Error("expected error when not connected")
+	}
+	if err := client.SendBinary([]byte("data")); err == nil {
+		t.Error("expected error when not connected")
+	}
+	if client.GetSessionInfo() != nil {
+		t.Error("expected nil session before connect")
+	}
+
+	ctx := context.Background()
+	_, err = client.Connect(ctx, request, runtimeObject)
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+
+	if client.GetSessionInfo() == nil {
+		t.Error("expected session info after connect")
+	}
+	if err := client.SendText("hello"); err != nil {
+		t.Errorf("SendText failed: %v", err)
+	}
+	if err := client.SendBinary([]byte{0x01, 0x02}); err != nil {
+		t.Errorf("SendBinary failed: %v", err)
+	}
+
+	client.Close()
+}
+
+func TestNewWebSocketClientAndConnectWithContext(t *testing.T) {
+	server := createTestWebSocketServer(t)
+	defer server.Close()
+
+	handler := &MockWebSocketHandler{}
+	request := &Request{
+		Protocol: String("ws"),
+		Pathname: String("/"),
+		Headers: map[string]*string{
+			"host": String(server.Listener.Addr().String()),
+		},
+	}
+	runtimeObject := &RuntimeObject{
+		WebSocketPingInterval: Int(0),
+		WebSocketHandler:      handler,
+	}
+
+	ctx := context.Background()
+	client, resp, err := NewWebSocketClientAndConnectWithContext(ctx, request, runtimeObject)
+	if err != nil {
+		t.Fatalf("NewWebSocketClientAndConnectWithContext failed: %v", err)
+	}
+	if client == nil || resp == nil {
+		t.Fatal("expected client and response")
+	}
+	if !client.IsConnected() {
+		t.Error("expected connected client")
+	}
+	client.Close()
+}
+
+func TestBuildWebSocketURL(t *testing.T) {
+	request := &Request{
+		Protocol: String("https"),
+		Domain:   String("example.com"),
+		Pathname: String("/ws"),
+		Query: map[string]*string{
+			"token": String("abc"),
+		},
+	}
+	urlStr, err := buildWebSocketURL(request)
+	if err != nil {
+		t.Fatalf("buildWebSocketURL failed: %v", err)
+	}
+	if urlStr != "wss://example.com/ws?token=abc" {
+		t.Errorf("unexpected url: %s", urlStr)
+	}
+
+	request = &Request{
+		Headers: map[string]*string{
+			"host": String("example.com"),
+		},
+	}
+	urlStr, err = buildWebSocketURL(request)
+	if err != nil {
+		t.Fatalf("buildWebSocketURL failed: %v", err)
+	}
+	if urlStr != "ws://example.com/" {
+		t.Errorf("unexpected default url: %s", urlStr)
+	}
+
+	_, err = buildWebSocketURL(nil)
+	if err == nil {
+		t.Error("expected error for nil request")
+	}
+
+	_, err = buildWebSocketURL(&Request{})
+	if err == nil {
+		t.Error("expected error when domain is missing")
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for dara array/core/date/error/model/retry/url/websocket gaps so overall `go test -cover ./...` reaches ≥90% statement coverage (90.1%).
- Production code unchanged; coverage evidence: `go test -coverprofile=coverage.txt ./...` then `go tool cover -func=coverage.txt`.
- Related functional fix (default HTTP timeouts): https://github.com/alibabacloud-go/tea/pull/161