### PR TITLE
fix: preserve and print non-empty Detail on SDKError

### DIFF
--- a/dara/core_test.go
+++ b/dara/core_test.go
@@ -372,7 +372,7 @@ func TestSDKError(t *testing.T) {
 		},
 	})
 	utils.AssertNotNil(t, err)
-	utils.AssertEqual(t, "SDKError:\n   StatusCode: 404\n   Code: code\n   Message: message\n   Data: {\"hostId\":\"github.com/alibabacloud/tea\",\"httpCode\":\"404\",\"recommend\":\"https://中文?q=a.b&product=c&requestId=123\",\"requestId\":\"dfadfa32cgfdcasd4313\"}\n", err.Error())
+	utils.AssertEqual(t, "SDKError:\n   StatusCode: 404\n   Code: code\n   Message: message\n   Detail: detail message\n   Data: {\"hostId\":\"github.com/alibabacloud/tea\",\"httpCode\":\"404\",\"recommend\":\"https://中文?q=a.b&product=c&requestId=123\",\"requestId\":\"dfadfa32cgfdcasd4313\"}\n", err.Error())
 
 	err.SetErrMsg("test")
 	utils.AssertEqual(t, "test", err.Error())

--- a/dara/error.go
+++ b/dara/error.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
+	"strings"
+
 	"github.com/alibabacloud-go/tea/tea"
 )
 
@@ -62,15 +64,22 @@ func TeaSDKError(err error) error {
 		})
 	}
 
-	if respErr, ok := err.(ResponseError); ok { 
-		return tea.NewSDKError(map[string]interface{}{
-			"code": StringValue(respErr.GetCode()),
-			"statusCode": IntValue(respErr.GetStatusCode()),
-			"message": respErr.Error(),
-			"description": StringValue(respErr.GetDescription()),
-			"data": respErr.GetData(),
+	if respErr, ok := err.(ResponseError); ok {
+		obj := map[string]interface{}{
+			"code":               StringValue(respErr.GetCode()),
+			"statusCode":         IntValue(respErr.GetStatusCode()),
+			"message":            respErr.Error(),
+			"description":        StringValue(respErr.GetDescription()),
+			"data":               respErr.GetData(),
 			"accessDeniedDetail": respErr.GetAccessDeniedDetail(),
-		})
+		}
+		// ResponseError does not require GetDetail(); copy when present and non-empty.
+		if dg, ok := err.(interface{ GetDetail() *string }); ok {
+			if d := strings.TrimSpace(StringValue(dg.GetDetail())); d != "" {
+				obj["detail"] = d
+			}
+		}
+		return tea.NewSDKError(obj)
 	}
 
 	if baseErr, ok := err.(BaseError); ok { 
@@ -181,9 +190,14 @@ func (err *SDKError) SetErrMsg(msg string) {
 
 func (err *SDKError) Error() string {
 	if err.errMsg == nil {
-		str := fmt.Sprintf("SDKError:\n   StatusCode: %d\n   Code: %s\n   Message: %s\n   Data: %s\n",
-			IntValue(err.StatusCode), StringValue(err.Code), StringValue(err.Message), StringValue(err.Data))
-		err.SetErrMsg(str)
+		var b strings.Builder
+		fmt.Fprintf(&b, "SDKError:\n   StatusCode: %d\n   Code: %s\n   Message: %s\n",
+			IntValue(err.StatusCode), StringValue(err.Code), StringValue(err.Message))
+		if d := strings.TrimSpace(StringValue(err.Detail)); d != "" {
+			fmt.Fprintf(&b, "   Detail: %s\n", d)
+		}
+		fmt.Fprintf(&b, "   Data: %s\n", StringValue(err.Data))
+		err.SetErrMsg(b.String())
 	}
 	return StringValue(err.errMsg)
 }

--- a/dara/error_test.go
+++ b/dara/error_test.go
@@ -3,6 +3,7 @@ package dara
 import (
 	"testing"
 
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/alibabacloud-go/tea/utils"
 )
 
@@ -22,9 +23,9 @@ func TestTeaSDKError(t *testing.T) {
 	utils.AssertNil(t, TeaSDKError(nil))
 
 	sdkErr := NewSDKError(map[string]interface{}{
-		"code":       "code",
-		"statusCode": 404,
-		"message":    "message",
+		"code":        "code",
+		"statusCode":  404,
+		"message":     "message",
 		"description": "description",
 		"detail":      "detail",
 		"accessDeniedDetail": map[string]interface{}{
@@ -33,8 +34,90 @@ func TestTeaSDKError(t *testing.T) {
 	})
 	converted := TeaSDKError(sdkErr)
 	utils.AssertNotNil(t, converted)
+	teaErr, ok := converted.(*tea.SDKError)
+	utils.AssertEqual(t, true, ok)
+	utils.AssertEqual(t, "detail", StringValue(teaErr.Detail))
+	utils.AssertEqual(t, true, contains(teaErr.Error(), "Detail: detail"))
 
 	plainErr := NewCastError(String("plain"))
 	converted = TeaSDKError(plainErr)
 	utils.AssertEqual(t, plainErr, converted)
 }
+
+func TestTeaSDKError_ResponseErrorCopiesDetail(t *testing.T) {
+	resp := &mockResponseError{
+		code:        String("InvalidParameter"),
+		statusCode:  Int(400),
+		message:     "code: 400, bad request id: r1",
+		description: String("desc"),
+		detail:      String("field X is invalid"),
+		data: map[string]interface{}{
+			"Message": "bad",
+		},
+	}
+	converted := TeaSDKError(resp)
+	teaErr, ok := converted.(*tea.SDKError)
+	utils.AssertEqual(t, true, ok)
+	utils.AssertEqual(t, "field X is invalid", StringValue(teaErr.GetDetail()))
+	utils.AssertEqual(t, true, contains(teaErr.Error(), "Detail: field X is invalid"))
+}
+
+func TestTeaSDKError_ResponseErrorOmitsEmptyDetail(t *testing.T) {
+	resp := &mockResponseError{
+		code:       String("InvalidParameter"),
+		statusCode: Int(400),
+		message:    "bad",
+		detail:     String("   "),
+	}
+	converted := TeaSDKError(resp)
+	teaErr := converted.(*tea.SDKError)
+	utils.AssertNil(t, teaErr.Detail)
+	utils.AssertEqual(t, false, contains(teaErr.Error(), "Detail:"))
+}
+
+func TestSDKError_ErrorOmitsEmptyDetail(t *testing.T) {
+	err := NewSDKError(map[string]interface{}{
+		"code":    "C",
+		"message": "M",
+		"detail":  "",
+	})
+	msg := err.Error()
+	utils.AssertEqual(t, false, contains(msg, "Detail:"))
+	utils.AssertEqual(t, true, contains(msg, "Code: C"))
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		(func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		})())
+}
+
+type mockResponseError struct {
+	code               *string
+	statusCode         *int
+	message            string
+	description        *string
+	detail             *string
+	data               map[string]interface{}
+	accessDeniedDetail map[string]interface{}
+	retryAfter         *int64
+	name               *string
+}
+
+func (m *mockResponseError) Error() string                              { return m.message }
+func (m *mockResponseError) GetName() *string                           { return m.name }
+func (m *mockResponseError) GetCode() *string                           { return m.code }
+func (m *mockResponseError) GetRetryAfter() *int64                      { return m.retryAfter }
+func (m *mockResponseError) GetStatusCode() *int                        { return m.statusCode }
+func (m *mockResponseError) GetAccessDeniedDetail() map[string]interface{} {
+	return m.accessDeniedDetail
+}
+func (m *mockResponseError) GetDescription() *string                    { return m.description }
+func (m *mockResponseError) GetData() map[string]interface{}            { return m.data }
+func (m *mockResponseError) GetDetail() *string                         { return m.detail }

--- a/tea/tea.go
+++ b/tea/tea.go
@@ -97,6 +97,7 @@ type SDKError struct {
 	Stack              *string
 	errMsg             *string
 	Description        *string
+	Detail             *string
 	AccessDeniedDetail map[string]interface{}
 }
 
@@ -205,6 +206,9 @@ func NewSDKError(obj map[string]interface{}) *SDKError {
 	if obj["description"] != nil {
 		err.Description = String(obj["description"].(string))
 	}
+	if obj["detail"] != nil {
+		err.Detail = String(obj["detail"].(string))
+	}
 	if detail := obj["accessDeniedDetail"]; detail != nil {
 		r := reflect.ValueOf(detail)
 		if r.Kind().String() == "map" {
@@ -261,11 +265,20 @@ func (err *SDKError) SetErrMsg(msg string) {
 	err.errMsg = String(msg)
 }
 
+func (err *SDKError) GetDetail() *string {
+	return err.Detail
+}
+
 func (err *SDKError) Error() string {
 	if err.errMsg == nil {
-		str := fmt.Sprintf("SDKError:\n   StatusCode: %d\n   Code: %s\n   Message: %s\n   Data: %s\n",
-			IntValue(err.StatusCode), StringValue(err.Code), StringValue(err.Message), StringValue(err.Data))
-		err.SetErrMsg(str)
+		var b strings.Builder
+		fmt.Fprintf(&b, "SDKError:\n   StatusCode: %d\n   Code: %s\n   Message: %s\n",
+			IntValue(err.StatusCode), StringValue(err.Code), StringValue(err.Message))
+		if d := strings.TrimSpace(StringValue(err.Detail)); d != "" {
+			fmt.Fprintf(&b, "   Detail: %s\n", d)
+		}
+		fmt.Fprintf(&b, "   Data: %s\n", StringValue(err.Data))
+		err.SetErrMsg(b.String())
 	}
 	return StringValue(err.errMsg)
 }

--- a/tea/tea_test.go
+++ b/tea/tea_test.go
@@ -205,6 +205,7 @@ func TestSDKError(t *testing.T) {
 			"recommend": "https://中文?q=a.b&product=c&requestId=123",
 		},
 		"description": "description",
+		"detail":      "detail message",
 		"accessDeniedDetail": map[string]interface{}{
 			"AuthAction":        "ram:ListUsers",
 			"AuthPrincipalType": "SubUser",
@@ -214,14 +215,24 @@ func TestSDKError(t *testing.T) {
 		},
 	})
 	utils.AssertNotNil(t, err)
-	utils.AssertEqual(t, "SDKError:\n   StatusCode: 404\n   Code: code\n   Message: message\n   Data: {\"hostId\":\"github.com/alibabacloud/tea\",\"httpCode\":\"404\",\"recommend\":\"https://中文?q=a.b&product=c&requestId=123\",\"requestId\":\"dfadfa32cgfdcasd4313\"}\n", err.Error())
+	utils.AssertEqual(t, "SDKError:\n   StatusCode: 404\n   Code: code\n   Message: message\n   Detail: detail message\n   Data: {\"hostId\":\"github.com/alibabacloud/tea\",\"httpCode\":\"404\",\"recommend\":\"https://中文?q=a.b&product=c&requestId=123\",\"requestId\":\"dfadfa32cgfdcasd4313\"}\n", err.Error())
 
 	err.SetErrMsg("test")
 	utils.AssertEqual(t, "test", err.Error())
 	utils.AssertEqual(t, 404, *err.StatusCode)
 	utils.AssertEqual(t, "description", *err.Description)
+	utils.AssertEqual(t, "detail message", *err.Detail)
+	utils.AssertEqual(t, "detail message", *err.GetDetail())
 	utils.AssertEqual(t, "ImplicitDeny", err.AccessDeniedDetail["NoPermissionType"])
 	utils.AssertEqual(t, 123, err.AccessDeniedDetail["UserId"])
+
+	err = NewSDKError(map[string]interface{}{
+		"code":    "code",
+		"message": "message",
+		"detail":  "   ",
+	})
+	utils.AssertNotNil(t, err)
+	utils.AssertEqual(t, "SDKError:\n   StatusCode: 0\n   Code: code\n   Message: message\n   Data: \n", err.Error())
 
 	err = NewSDKError(map[string]interface{}{
 		"statusCode": "404",


### PR DESCRIPTION
## Summary
- Copy GetDetail from ResponseError into tea.SDKError when converting via TeaSDKError.
- Store Detail on tea.SDKError and include it in Error() only when non-empty.